### PR TITLE
Watch for os.Interrupt signals, if `-interrupt-wait` is set, then wait.

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,8 +47,9 @@ func main() {
 	go func() {
 		c := make(chan os.Signal, 1)
 		signal.Notify(c, os.Interrupt)
-		<-c
+		sig := <-c
 		time.Sleep(time.Duration(interruptWaitSeconds) * time.Second)
+		abort("receiving signal '%s'", sig.String())
 	}()
 
 	lokiUrl = stringOrDefault(lokiUrl, os.Getenv("LOKI_ADDR"))

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"os/signal"
 	"path"
 	"time"
 
@@ -25,10 +26,11 @@ import (
 
 func main() {
 	var (
-		lokiUrl   string
-		username  string
-		password  string
-		rawLabels string
+		lokiUrl              string
+		username             string
+		password             string
+		rawLabels            string
+		interruptWaitSeconds int64
 	)
 
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
@@ -36,10 +38,18 @@ func main() {
 	fs.StringVar(&username, "username", "", "Username for basic auth. Defaults to $LOKI_USERNAME if not set.")
 	fs.StringVar(&password, "password", "", "Password for basic auth. Defaults to $LOKI_PASSWORD if not set.")
 	fs.StringVar(&rawLabels, "labels", `{job="lokitee"}`, `Labels to inject for logs. i.e., {app="shell"}`)
+	fs.Int64Var(&interruptWaitSeconds, "interrupt-wait", 0, "Number of seconds to delay exiting if sending an interrupt signal like SIGTERM is sent")
 
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		abort("error: could not parse flags: %s", err)
 	}
+
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt)
+		<-c
+		time.Sleep(time.Duration(interruptWaitSeconds) * time.Second)
+	}()
 
 	lokiUrl = stringOrDefault(lokiUrl, os.Getenv("LOKI_ADDR"))
 	username = stringOrDefault(username, os.Getenv("LOKI_USERNAME"))


### PR DESCRIPTION
This will allow the program piping stdin to have an opportunity to log some information about why it's terminating or what cleanup it might be doing.

`os.Interrupt` is the better alternative to checking for `syscall.SIGTERM` and the like because it's more cross-platform apparently.